### PR TITLE
feat: allow calling `harden` before `lockdown`

### DIFF
--- a/xs/sources/xsLockdown.c
+++ b/xs/sources/xsLockdown.c
@@ -333,8 +333,8 @@ void fx_harden(txMachine* the)
 	txSlot* list;
 	txSlot* item;
 
-	if (!(mxProgram.value.reference->flag & XS_DONT_MARSHALL_FLAG))
-		mxTypeError("call lockdown before harden");
+//	if (!(mxProgram.value.reference->flag & XS_DONT_MARSHALL_FLAG))
+//		mxTypeError("call lockdown before harden");
 
 	if (mxArgc == 0)
 		return;


### PR DESCRIPTION
This minor surgery is needed to allow the SES shim to use its own `lockdown()` with Moddable's native `harden()`.  That's the most expedient way for the Agoric SDK to use native `harden()` with its performance benefits.

We may or may not want to upstream this change (or moral equivalent), depending upon the effort required to fully adopt the native `lockdown()`.
